### PR TITLE
ci: fix docker push

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -101,5 +101,7 @@ jobs:
           export IMAGE_TAG=$(docker load < result | grep -Po 'Loaded image.*: \K.*')
           echo "Pushing image ${IMAGE_TAG} to Docker Hub"
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
-          docker push "${IMAGE_TAG}" matterlabsrobot/"${IMAGE_TAG}"
-          docker push "${IMAGE_TAG}" matterlabsrobot/"${IMAGE_TAG%:*}:latest"
+          docker tag "${IMAGE_TAG}" matterlabsrobot/"${IMAGE_TAG}"
+          docker push matterlabsrobot/"${IMAGE_TAG}"
+          docker tag matterlabsrobot/"${IMAGE_TAG}" matterlabsrobot/"${IMAGE_TAG%:*}:latest"
+          docker push matterlabsrobot/"${IMAGE_TAG%:*}:latest"


### PR DESCRIPTION
docker does not support pushing and tagging with a different name in one go as podman does.