### PR TITLE
fix(tee-key-preexec): don't hash public key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,7 +2401,6 @@ dependencies = [
  "hex",
  "k256",
  "rand",
- "sha2",
  "teepot",
  "tracing",
  "tracing-log",

--- a/bin/tee-key-preexec/Cargo.toml
+++ b/bin/tee-key-preexec/Cargo.toml
@@ -13,7 +13,6 @@ anyhow.workspace = true
 hex.workspace = true
 k256.workspace = true
 rand.workspace = true
-sha2.workspace = true
 teepot.workspace = true
 tracing-log.workspace = true
 tracing-subscriber.workspace = true

--- a/bin/tee-key-preexec/src/main.rs
+++ b/bin/tee-key-preexec/src/main.rs
@@ -9,8 +9,6 @@
 use anyhow::{Context, Result};
 use hex::ToHex;
 use k256::ecdsa::SigningKey;
-use sha2::Digest;
-use sha2::Sha256;
 use std::env;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
@@ -41,9 +39,8 @@ fn main_with_error() -> Result<()> {
     let mut rng = rand::thread_rng();
     let signing_key = SigningKey::random(&mut rng);
     let verifying_key_bytes = signing_key.verifying_key().to_sec1_bytes();
-    let hash_verifying_key = Sha256::digest(verifying_key_bytes);
     let signing_key_string = signing_key.to_bytes().encode_hex::<String>();
-    let tee_type = match get_quote(&hash_verifying_key) {
+    let tee_type = match get_quote(&verifying_key_bytes) {
         Ok(quote) => {
             // save quote to file
             std::fs::write(TEE_QUOTE_FILE, quote)?;


### PR DESCRIPTION
No need to hash the public key for the attestation report data.