### PR TITLE
fix: cleanup the nix packages

### DIFF
--- a/packages/container-self-attestation-test-sgx-azure/default.nix
+++ b/packages/container-self-attestation-test-sgx-azure/default.nix
@@ -1,14 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
 { pkgs
-, vat
 , nixsgx
 , curl
 , teepot
 , bash
 , coreutils
 , openssl
-, vault
 }:
 let manifest = ./tee-self-attestation-test.manifest.toml;
 in pkgs.dockerTools.buildLayeredImage {

--- a/packages/container-self-attestation-test-sgx-dcap/default.nix
+++ b/packages/container-self-attestation-test-sgx-dcap/default.nix
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
 { pkgs
-, vat
 , nixsgx
 , curl
 , teepot

--- a/packages/container-vault-admin-sgx-azure/default.nix
+++ b/packages/container-vault-admin-sgx-azure/default.nix
@@ -1,14 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
 { pkgs
-, vat
 , nixsgx
 , curl
 , teepot
 , bash
 , coreutils
 , openssl
-, vault
 }:
 let manifest = ./tee-vault-admin.manifest.toml;
 in pkgs.dockerTools.buildLayeredImage {
@@ -20,13 +18,12 @@ in pkgs.dockerTools.buildLayeredImage {
   contents = pkgs.buildEnv {
     name = "image-root";
 
-    paths = with pkgs.dockerTools; with nixsgx; with teepot;[
+    paths = with pkgs.dockerTools; with nixsgx;[
       bash
       coreutils
-      openssl
-      vault
+      openssl.out
       azure-dcap-client
-      curl
+      curl.out
       teepot.teepot.tee_vault_admin
       gramine
       restart-aesmd

--- a/packages/container-vault-sgx-azure/default.nix
+++ b/packages/container-vault-sgx-azure/default.nix
@@ -26,7 +26,8 @@ in pkgs.dockerTools.buildLayeredImage {
       teepot.teepot.tee_ratls_preexec
       vault
       azure-dcap-client
-      curl
+      openssl.out
+      curl.out
       vat.vault-auth-tee
       gramine
       restart-aesmd

--- a/packages/container-vault-start-config/default.nix
+++ b/packages/container-vault-start-config/default.nix
@@ -1,13 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
 
-# TODO: This derivation is a temporary workaround for
-# creating a self-signed certificate for Vault and the unseal TEE.
-# It will be replaced with real RA-TLS.
 { lib
 , stdenv
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   name = "container-vault-start-config";
   src = with lib.fileset; toSource {
     root = ./.;

--- a/packages/container-vault-unseal-sgx-azure/default.nix
+++ b/packages/container-vault-unseal-sgx-azure/default.nix
@@ -8,7 +8,6 @@
 , bash
 , coreutils
 , openssl
-, vault
 }:
 let manifest = ./tee-vault-unseal.manifest.toml;
 in pkgs.dockerTools.buildLayeredImage {
@@ -20,13 +19,12 @@ in pkgs.dockerTools.buildLayeredImage {
   contents = pkgs.buildEnv {
     name = "image-root";
 
-    paths = with pkgs.dockerTools; with nixsgx; with teepot;[
+    paths = with pkgs.dockerTools; with nixsgx;[
       bash
       coreutils
-      openssl
-      vault
+      openssl.out
       azure-dcap-client
-      curl
+      curl.out
       vat.vault-auth-tee.sha
       teepot.teepot.tee_vault_unseal
       gramine

--- a/packages/container-vault-unseal/default.nix
+++ b/packages/container-vault-unseal/default.nix
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
-{ lib
-, dockerTools
+{ dockerTools
 , nixsgx
 , teepot
 , buildEnv
 , curl
-, ...
 }:
 dockerTools.buildLayeredImage {
   name = "vault-unseal";
@@ -18,7 +16,7 @@ dockerTools.buildLayeredImage {
     name = "image-root";
     paths = with dockerTools; with nixsgx;[
       azure-dcap-client
-      curl
+      curl.out
       sgx-dcap.quote_verify
       usrBinEnv
       binSh

--- a/packages/container-verify-attestation-sgx-azure/default.nix
+++ b/packages/container-verify-attestation-sgx-azure/default.nix
@@ -1,13 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
-{ lib
-, dockerTools
+{ dockerTools
 , buildEnv
 , teepot
 , openssl
 , curl
 , nixsgx
-, ...
 }:
 dockerTools.buildLayeredImage {
   name = "verify-attestation-sgx-azure";
@@ -15,9 +13,9 @@ dockerTools.buildLayeredImage {
 
   config.Cmd = [ "${teepot.teepot.verify_attestation}/bin/verify-attestation" ];
   config.Env = [
-   "LD_LIBRARY_PATH=/lib"
-"AZDCAP_DEBUG_LOG_LEVEL=ignore"
-"AZDCAP_COLLATERAL_VERSION=v4"
+    "LD_LIBRARY_PATH=/lib"
+    "AZDCAP_DEBUG_LOG_LEVEL=ignore"
+    "AZDCAP_COLLATERAL_VERSION=v4"
   ];
   contents = buildEnv {
     name = "image-root";

--- a/packages/container-verify-attestation-sgx-dcap/default.nix
+++ b/packages/container-verify-attestation-sgx-dcap/default.nix
@@ -1,13 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
-{ lib
-, dockerTools
+{ dockerTools
 , buildEnv
 , teepot
 , openssl
 , curl
 , nixsgx
-, ...
 }:
 dockerTools.buildLayeredImage {
   name = "verify-attestation-sgx-dcap";

--- a/packages/teepot/default.nix
+++ b/packages/teepot/default.nix
@@ -1,15 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2024 Matter Labs
 { lib
-, gccStdenv
 , makeRustPlatform
 , nixsgx
 , pkg-config
 , rust-bin
-, ...
 }:
 let
-  cargoToml = (builtins.fromTOML (builtins.readFile ../../Cargo.toml));
+  cargoToml = builtins.fromTOML (builtins.readFile ../../Cargo.toml);
   rustVersion = rust-bin.fromRustupToolchainFile ../../rust-toolchain.toml;
   rustPlatform = makeRustPlatform {
     cargo = rustVersion;
@@ -18,7 +16,7 @@ let
 in
 rustPlatform.buildRustPackage {
   pname = cargoToml.package.name;
-  version = cargoToml.workspace.package.version;
+  inherit (cargoToml.workspace.package) version;
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
`curl` and `openssl` have to be specified with `.out`