### PR TITLE
feat: remove mio workaround with gramine 1.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
         "snowfall-lib": "snowfall-lib"
       },
       "locked": {
-        "lastModified": 1717758565,
-        "narHash": "sha256-yscuZ3ixjwTkqS6ew5cB3Uvy9e807szRlMoPSyQuRJM=",
+        "lastModified": 1718699802,
+        "narHash": "sha256-1Q+xMLgggLj2W/u8M1zJeqqGMDRoEjIeve12Jt4EAXM=",
         "owner": "matter-labs",
         "repo": "nixsgx",
-        "rev": "49a1ae79d92ccb6ed7cabfe5c5042b1399e3cd3e",
+        "rev": "d9eb744741368eb13fc2247cb3603551828d623f",
         "type": "github"
       },
       "original": {

--- a/teepot-crate.nix
+++ b/teepot-crate.nix
@@ -45,7 +45,6 @@ let
       ];
     };
 
-    RUSTFLAGS = "--cfg mio_unsupported_force_waker_pipe";
     checkType = "debug";
   };
   cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {


### PR DESCRIPTION
gramine 1.7 now supports eventfd.
Update nixsgx flake and remove the `RUSTFLAGS`.