### PR TITLE
chore: update GitHub Actions workflow configuration

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,18 +13,15 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [ matterlabs-ci-runner ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: cachix/install-nix-action@v27
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
-      - uses: cachix/cachix-action@v15
-        with:
-          name: nixsgx
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          extraPullNames: vault-auth-tee
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
+            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
       - name: Enable magic Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 
@@ -32,18 +29,15 @@ jobs:
 
   build:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: [ matterlabs-ci-runner ]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: cachix/install-nix-action@v27
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
-      - uses: cachix/cachix-action@v15
-        with:
-          name: nixsgx
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          extraPullNames: vault-auth-tee
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
+            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
       - name: Enable magic Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 
@@ -52,7 +46,7 @@ jobs:
 
   push_to_docker:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [ matterlabs-ci-runner ]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.nixpackage }}
       cancel-in-progress: true
@@ -74,11 +68,8 @@ jobs:
         with:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
-      - uses: cachix/cachix-action@v15
-        with:
-          name: nixsgx
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          extraPullNames: vault-auth-tee
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
+            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
       - name: Enable magic Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 


### PR DESCRIPTION
This update removes usage of cachix/cachix-action and updates job runner from ubuntu-latest to matterlabs-ci-runner in the GitHub Actions workflow. New configurations have been added for trusted-public-keys and substituters. 