### PR TITLE
Replace secp256k1 with k256 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,6 +2309,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
+dependencies = [
+ "rand",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,8 +2557,8 @@ name = "tee-key-preexec"
 version = "0.1.2-alpha.1"
 dependencies = [
  "anyhow",
- "k256",
  "rand",
+ "secp256k1",
  "teepot",
  "tracing",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ getrandom = "0.2.14"
 hex = { version = "0.4.3", features = ["std"], default-features = false }
 intel-tee-quote-verification-rs = { package = "teepot-tee-quote-verification-rs", path = "crates/teepot-tee-quote-verification-rs", version = "0.2.3-alpha.1" }
 intel-tee-quote-verification-sys = { version = "0.2.1" }
-k256 = "0.13"
+secp256k1 = { version = "0.29", features = ["rand-std"] }
 log = "0.4"
 num-integer = "0.1.46"
 num-traits = "0.2.18"

--- a/bin/tee-key-preexec/Cargo.toml
+++ b/bin/tee-key-preexec/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-k256.workspace = true
 rand.workspace = true
+secp256k1.workspace = true
 teepot.workspace = true
 tracing.workspace = true
 tracing-log.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -29,11 +29,10 @@ allow = [
   "Unlicense",
   "MPL-2.0",
   "Unicode-DFS-2016",
-  #  "CC0-1.0", # not yet seen
   "BSD-2-Clause",
   "BSD-3-Clause",
   "OpenSSL",
-  "Unicode-3.0",
+  "CC0-1.0",
 ]
 deny = []
 allow-osi-fsf-free = "neither"


### PR DESCRIPTION
Rationale: we already have secp256k1 in our dependencies, as suggested by Igor:
https://github.com/matter-labs/zksync-era/pull/2333#discussion_r1656531731