### PR TITLE
fix(container-vault-unseal-sgx-azure): correct `VAULT_AUTH_TEE_SHA256_FILE`

### DIFF
--- a/packages/container-vault-unseal-sgx-azure/default.nix
+++ b/packages/container-vault-unseal-sgx-azure/default.nix
@@ -38,7 +38,7 @@ nixsgxLib.mkSGXContainer {
         ### Enclave security ###
         ALLOWED_TCB_LEVELS = "SwHardeningNeeded";
 
-        VAULT_AUTH_TEE_SHA256 = "${vat.vault-auth-tee.sha}/share/vault-auth-tee.sha256";
+        VAULT_AUTH_TEE_SHA256_FILE = "${vat.vault-auth-tee.sha}/share/vault-auth-tee.sha256";
         ### TODO: remove hardcoded version ###
         VAULT_AUTH_TEE_VERSION = "0.1.0+dev";
       };


### PR DESCRIPTION
use the correct environment variable name... sigh