### PR TITLE
fix: use `performance_multiplier`

### DIFF
--- a/packages/container-vault-start-config/config.hcl
+++ b/packages/container-vault-start-config/config.hcl
@@ -22,7 +22,8 @@ storage "raft" {
 
   # Parameter needed because of slow plugin loading
   # may be relaxed for faster machines
-  # performance_multiplier = 200
+  # see also https://github.com/hashicorp/vault/issues/28009
+  performance_multiplier = 10
   # autopilot_reconcile_interval = "120s"
   # autopilot_update_interval    = "60s"
 


### PR DESCRIPTION
The vault instances lose the raft leader status, while loading the `vault-auth-tee` plugin, because the gramine enviroment slows down the `execve` significantly.

Using `performance_multiplier` relaxes the timeouts for the raft protocol.

see also: https://github.com/hashicorp/vault/issues/28009