### PR TITLE
fix(vault): maybe fix `netpollBreak` issues

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
         "snowfall-lib": "snowfall-lib"
       },
       "locked": {
-        "lastModified": 1719916365,
-        "narHash": "sha256-RzCFbGAHq6rTY4ctrmazGIx59qXtfrVfEnIe+L0leTo=",
+        "lastModified": 1723120465,
+        "narHash": "sha256-sWu5lKy71hHnSwydhwzG2XgSehjvLfK2iuUtNimvGkg=",
         "owner": "matter-labs",
         "repo": "nixsgx",
-        "rev": "0309a20ee5bf12b7390aa6795409b448420e80f2",
+        "rev": "b080c32f2aa8b3d4b4bc4356a8a513279b6f82ab",
         "type": "github"
       },
       "original": {

--- a/packages/container-vault-sgx-azure/default.nix
+++ b/packages/container-vault-sgx-azure/default.nix
@@ -84,6 +84,11 @@ nixsgxLib.mkSGXContainer {
     sys.stack.size = "16M";
     # vault needs flock
     sys.experimental__enable_flock = true;
+
+    # recent golang switched to eventfd for netpoll
+    # https://github.com/golang/go/commit/d068c2cb620c1daeedc8b9cce488af45a6c2c889
+    # enable it to mitigate surprises for golang >= 1.23
+    sys.insecure__allow_eventfd = true;
   };
 }
 


### PR DESCRIPTION
- Updated the flake.lock for nixsgx dependency with new revision to get a patched gramine https://github.com/matter-labs/nixsgx/pull/54

- Enabled `sys.insecure__allow_eventfd` to support recent golang changes in the `netpoll` implementation