### PR TITLE
fix(container-vault-sgx-azure): remove insecure eventfd setting

### DIFF
--- a/packages/container-vault-sgx-azure/default.nix
+++ b/packages/container-vault-sgx-azure/default.nix
@@ -84,11 +84,6 @@ nixsgxLib.mkSGXContainer {
     sys.stack.size = "16M";
     # vault needs flock
     sys.experimental__enable_flock = true;
-
-    # recent golang switched to eventfd for netpoll
-    # https://github.com/golang/go/commit/d068c2cb620c1daeedc8b9cce488af45a6c2c889
-    # enable it to mitigate surprises for golang >= 1.23
-    sys.insecure__allow_eventfd = true;
   };
 }
 


### PR DESCRIPTION
Removed the sys.insecure__allow_eventfd setting, because gramine has a secure eventfd implementation since
[v1.7](https://github.com/gramineproject/gramine/releases/tag/v1.7).