### PR TITLE
feat(tee-key-preexec): add cmdline arg for env prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4780,6 +4780,7 @@ name = "tee-key-preexec"
 version = "0.1.2-alpha.1"
 dependencies = [
  "anyhow",
+ "clap",
  "rand",
  "secp256k1 0.29.0",
  "teepot",

--- a/bin/tee-key-preexec/Cargo.toml
+++ b/bin/tee-key-preexec/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+clap.workspace = true
 rand.workspace = true
 secp256k1.workspace = true
 teepot.workspace = true


### PR DESCRIPTION
- Introduced `clap` for command-line argument parsing.
- Replaced manual argument handling with `clap`'s derived `Args` struct.
- Updated environmental variables to use dynamic prefixes.