### PR TITLE
feat(verify-era-proof-attestation): added continuous mode with attestation policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1056,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2833,6 +2849,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -5617,12 +5645,17 @@ version = "0.1.2-alpha.1"
 dependencies = [
  "anyhow",
  "clap",
+ "ctrlc",
  "hex",
+ "jsonrpsee-types",
  "reqwest 0.12.7",
  "secp256k1 0.29.0",
  "serde",
  "teepot",
  "tokio",
+ "tracing",
+ "tracing-log 0.2.0",
+ "tracing-subscriber",
  "url",
  "zksync_basic_types",
  "zksync_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ actix-http = "3"
 actix-tls = "3"
 actix-web = { version = "4.5", features = ["rustls-0_22"] }
 anyhow = "1.0.82"
+ctrlc = "3.4"
 awc = { version = "3.4", features = ["rustls-0_22-webpki-roots"] }
 base64 = "0.22.0"
 bitflags = "2.5"
@@ -34,6 +35,7 @@ getrandom = "0.2.14"
 hex = { version = "0.4.3", features = ["std"], default-features = false }
 intel-tee-quote-verification-rs = { package = "teepot-tee-quote-verification-rs", path = "crates/teepot-tee-quote-verification-rs", version = "0.2.3-alpha.1" }
 intel-tee-quote-verification-sys = { version = "0.2.1" }
+jsonrpsee-types = { version = "0.23", default-features = false }
 secp256k1 = { version = "0.29", features = ["rand-std", "global-context"] }
 log = "0.4"
 num-integer = "0.1.46"

--- a/bin/verify-era-proof-attestation/Cargo.toml
+++ b/bin/verify-era-proof-attestation/Cargo.toml
@@ -1,20 +1,25 @@
 [package]
-name = "verify-era-proof-attestation"
-version.workspace = true
-edition.workspace = true
 authors.workspace = true
+edition.workspace = true
 license.workspace = true
+name = "verify-era-proof-attestation"
 repository.workspace = true
+version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+ctrlc.workspace = true
 hex.workspace = true
+jsonrpsee-types.workspace = true
 reqwest.workspace = true
 secp256k1.workspace = true
 serde.workspace = true
 teepot.workspace = true
 tokio.workspace = true
+tracing.workspace = true
+tracing-log.workspace = true
+tracing-subscriber.workspace = true
 url.workspace = true
 zksync_basic_types.workspace = true
 zksync_types.workspace = true

--- a/bin/verify-era-proof-attestation/src/args.rs
+++ b/bin/verify-era-proof-attestation/src/args.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2023-2024 Matter Labs
+
+use anyhow::{anyhow, Result};
+use clap::{ArgGroup, Args, Parser};
+use std::time::Duration;
+use teepot::sgx::{parse_tcb_levels, EnumSet, TcbLevel};
+use tracing_subscriber::filter::LevelFilter;
+use url::Url;
+use zksync_basic_types::L1BatchNumber;
+use zksync_types::L2ChainId;
+
+#[derive(Parser, Debug, Clone)]
+#[command(author = "Matter Labs", version, about = "SGX attestation and batch signature verifier", long_about = None)]
+#[clap(group(
+    ArgGroup::new("mode")
+        .required(true)
+        .args(&["batch_range", "continuous"]),
+))]
+pub struct Arguments {
+    #[clap(long, default_value_t = LevelFilter::WARN, value_parser = LogLevelParser)]
+    pub log_level: LevelFilter,
+    /// The batch number or range of batch numbers to verify the attestation and signature (e.g.,
+    /// "42" or "42-45"). This option is mutually exclusive with the `--continuous` mode.
+    #[clap(short = 'n', long = "batch", value_parser = parse_batch_range)]
+    pub batch_range: Option<(L1BatchNumber, L1BatchNumber)>,
+    /// Continuous mode: keep verifying new batches until interrupted. This option is mutually
+    /// exclusive with the `--batch` option.
+    #[clap(long, value_name = "FIRST_BATCH")]
+    pub continuous: Option<L1BatchNumber>,
+    /// URL of the RPC server to query for the batch attestation and signature.
+    #[clap(long = "rpc")]
+    pub rpc_url: Url,
+    /// Chain ID of the network to query.
+    #[clap(long = "chain", default_value_t = L2ChainId::default().as_u64())]
+    pub chain_id: u64,
+    /// Rate limit between requests in milliseconds.
+    #[clap(long, default_value = "0", value_parser = parse_duration)]
+    pub rate_limit: Duration,
+    /// Criteria for valid attestation policy. Invalid proofs will be rejected.
+    #[clap(flatten)]
+    pub attestation_policy: AttestationPolicyArgs,
+}
+
+/// Attestation policy implemented as a set of criteria that must be met by SGX attestation.
+#[derive(Args, Debug, Clone)]
+pub struct AttestationPolicyArgs {
+    /// Comma-separated list of allowed hex-encoded SGX mrsigners. Batch attestation must consist of
+    /// one of these mrsigners. If the list is empty, the mrsigner check is skipped.
+    #[arg(long = "mrsigners")]
+    pub sgx_mrsigners: Option<String>,
+    /// Comma-separated list of allowed hex-encoded SGX mrenclaves. Batch attestation must consist
+    /// of one of these mrenclaves. If the list is empty, the mrenclave check is skipped.
+    #[arg(long = "mrenclaves")]
+    pub sgx_mrenclaves: Option<String>,
+    /// Comma-separated list of allowed TCB levels. If the list is empty, the TCB level check is
+    /// skipped. Allowed values: Ok, ConfigNeeded, ConfigAndSwHardeningNeeded, SwHardeningNeeded,
+    /// OutOfDate, OutOfDateConfigNeeded.
+    #[arg(long, value_parser = parse_tcb_levels, default_value = "Ok")]
+    pub sgx_allowed_tcb_levels: EnumSet<TcbLevel>,
+}
+
+fn parse_batch_range(s: &str) -> Result<(L1BatchNumber, L1BatchNumber)> {
+    let parse = |s: &str| {
+        s.parse::<u32>()
+            .map(L1BatchNumber::from)
+            .map_err(|e| anyhow!(e))
+    };
+    match s.split_once('-') {
+        Some((start, end)) => {
+            let (start, end) = (parse(start)?, parse(end)?);
+            if start > end {
+                Err(anyhow!(
+                    "Start batch number ({}) must be less than or equal to end batch number ({})",
+                    start,
+                    end
+                ))
+            } else {
+                Ok((start, end))
+            }
+        }
+        None => {
+            let batch_number = parse(s)?;
+            Ok((batch_number, batch_number))
+        }
+    }
+}
+
+fn parse_duration(s: &str) -> Result<Duration> {
+    let millis = s.parse()?;
+    Ok(Duration::from_millis(millis))
+}
+
+#[derive(Clone)]
+struct LogLevelParser;
+
+impl clap::builder::TypedValueParser for LogLevelParser {
+    type Value = LevelFilter;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        clap::builder::TypedValueParser::parse(self, cmd, arg, value.to_owned())
+    }
+
+    fn parse(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: std::ffi::OsString,
+    ) -> std::result::Result<Self::Value, clap::Error> {
+        use std::str::FromStr;
+        let p = clap::builder::PossibleValuesParser::new([
+            "off", "error", "warn", "info", "debug", "trace",
+        ]);
+        let v = p.parse(cmd, arg, value)?;
+
+        Ok(LevelFilter::from_str(&v).unwrap())
+    }
+}

--- a/bin/verify-era-proof-attestation/src/client.rs
+++ b/bin/verify-era-proof-attestation/src/client.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2023-2024 Matter Labs
+
+use anyhow::{anyhow, Context, Result};
+use url::Url;
+use zksync_basic_types::{L1BatchNumber, H256};
+use zksync_types::L2ChainId;
+use zksync_web3_decl::{
+    client::{Client as NodeClient, L2},
+    error::ClientRpcContext,
+    namespaces::ZksNamespaceClient,
+};
+
+pub trait JsonRpcClient {
+    async fn get_root_hash(&self, batch_number: L1BatchNumber) -> Result<H256>;
+    // TODO implement get_tee_proofs(batch_number, tee_type) once https://crates.io/crates/zksync_web3_decl crate is updated
+}
+
+pub struct MainNodeClient(NodeClient<L2>);
+
+impl MainNodeClient {
+    pub fn new(rpc_url: Url, chain_id: u64) -> Result<Self> {
+        let node_client = NodeClient::http(rpc_url.into())
+            .context("failed creating JSON-RPC client for main node")?
+            .for_network(
+                L2ChainId::try_from(chain_id)
+                    .map_err(anyhow::Error::msg)?
+                    .into(),
+            )
+            .build();
+
+        Ok(MainNodeClient(node_client))
+    }
+}
+
+impl JsonRpcClient for MainNodeClient {
+    async fn get_root_hash(&self, batch_number: L1BatchNumber) -> Result<H256> {
+        self.0
+            .get_l1_batch_details(batch_number)
+            .rpc_context("get_l1_batch_details")
+            .await?
+            .and_then(|res| res.base.root_hash)
+            .ok_or_else(|| anyhow!("No root hash found for batch #{}", batch_number))
+    }
+}

--- a/bin/verify-era-proof-attestation/src/proof.rs
+++ b/bin/verify-era-proof-attestation/src/proof.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2023-2024 Matter Labs
+
+use anyhow::{bail, Result};
+use jsonrpsee_types::error::ErrorObject;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio::sync::watch;
+use tracing::{error, warn};
+use url::Url;
+use zksync_basic_types::L1BatchNumber;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetProofsRequest {
+    pub jsonrpc: String,
+    pub id: u32,
+    pub method: String,
+    pub params: (L1BatchNumber, String),
+}
+
+pub async fn get_proofs(
+    stop_receiver: &mut watch::Receiver<bool>,
+    batch_number: L1BatchNumber,
+    http_client: &Client,
+    rpc_url: &Url,
+) -> Result<Vec<Proof>> {
+    let mut proofs_request = GetProofsRequest::new(batch_number);
+    let mut retries = 0;
+    let mut backoff = Duration::from_secs(1);
+    let max_backoff = Duration::from_secs(128);
+    let retry_backoff_multiplier: f32 = 2.0;
+
+    while !*stop_receiver.borrow() {
+        let proofs = proofs_request
+            .send(stop_receiver, http_client, rpc_url)
+            .await?;
+
+        if !proofs.is_empty() {
+            return Ok(proofs);
+        }
+
+        retries += 1;
+        warn!(
+            batch_no = batch_number.0, retries,
+            "No TEE proofs found for batch #{}. They may not be ready yet. Retrying in {} milliseconds.",
+            batch_number, backoff.as_millis(),
+        );
+
+        tokio::time::timeout(backoff, stop_receiver.changed())
+            .await
+            .ok();
+
+        backoff = std::cmp::min(backoff.mul_f32(retry_backoff_multiplier), max_backoff);
+    }
+
+    Ok(vec![])
+}
+
+impl GetProofsRequest {
+    pub fn new(batch_number: L1BatchNumber) -> Self {
+        GetProofsRequest {
+            jsonrpc: "2.0".to_string(),
+            id: 1,
+            method: "unstable_getTeeProofs".to_string(),
+            params: (batch_number, "sgx".to_string()),
+        }
+    }
+
+    pub async fn send(
+        &mut self,
+        stop_receiver: &mut watch::Receiver<bool>,
+        http_client: &Client,
+        rpc_url: &Url,
+    ) -> Result<Vec<Proof>> {
+        let mut retries = 0;
+        let max_retries = 5;
+        let mut backoff = Duration::from_secs(1);
+        let max_backoff = Duration::from_secs(128);
+        let retry_backoff_multiplier: f32 = 2.0;
+        let mut response = None;
+
+        while !*stop_receiver.borrow() {
+            let result = http_client
+                .post(rpc_url.clone())
+                .json(self)
+                .send()
+                .await?
+                .error_for_status()?
+                .json::<GetProofsResponse>()
+                .await;
+
+            match result {
+                Ok(res) => match res.error {
+                    None => {
+                        response = Some(res);
+                        break;
+                    }
+                    Some(error) => {
+                        // Handle corner case, where the old RPC interface expects 'Sgx'
+                        if let Some(data) = error.data() {
+                            if data.get().contains("unknown variant `sgx`, expected `Sgx`") {
+                                self.params.1 = "Sgx".to_string();
+                                continue;
+                            }
+                        }
+                        error!(?error, "received JSONRPC error {error:?}");
+                        bail!("JSONRPC error {error:?}");
+                    }
+                },
+                Err(err) => {
+                    retries += 1;
+                    if retries >= max_retries {
+                        return Err(anyhow::anyhow!(
+                            "Failed to send request to {} after {} retries: {}. Request details: {:?}",
+                            rpc_url,
+                            max_retries,
+                            err,
+                            self
+                        ));
+                    }
+                    warn!(
+                        %err,
+                        "Failed to send request to {rpc_url}. {retries}/{max_retries}, retrying in {} milliseconds. Request details: {:?}",
+                        backoff.as_millis(),
+                        self
+                    );
+                    tokio::time::timeout(backoff, stop_receiver.changed())
+                        .await
+                        .ok();
+                    backoff = std::cmp::min(backoff.mul_f32(retry_backoff_multiplier), max_backoff);
+                }
+            };
+        }
+
+        Ok(response.map_or_else(Vec::new, |res| res.result.unwrap_or_default()))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetProofsResponse {
+    pub jsonrpc: String,
+    pub result: Option<Vec<Proof>>,
+    pub id: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorObject<'static>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Proof {
+    pub l1_batch_number: u32,
+    pub tee_type: String,
+    pub pubkey: Vec<u8>,
+    pub signature: Vec<u8>,
+    pub proof: Vec<u8>,
+    pub proved_at: String,
+    pub attestation: Vec<u8>,
+}

--- a/bin/verify-era-proof-attestation/src/verification.rs
+++ b/bin/verify-era-proof-attestation/src/verification.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2023-2024 Matter Labs
+
+use anyhow::{Context, Result};
+use hex::encode;
+use secp256k1::{constants::PUBLIC_KEY_SIZE, ecdsa::Signature, Message, PublicKey};
+use teepot::{
+    client::TcbLevel,
+    sgx::{tee_qv_get_collateral, verify_quote_with_collateral, QuoteVerificationResult},
+};
+use tracing::{debug, info, warn};
+use zksync_basic_types::{L1BatchNumber, H256};
+
+use crate::args::AttestationPolicyArgs;
+use crate::client::JsonRpcClient;
+
+pub async fn verify_batch_proof(
+    quote_verification_result: &QuoteVerificationResult<'_>,
+    attestation_policy: &AttestationPolicyArgs,
+    node_client: &impl JsonRpcClient,
+    signature: &[u8],
+    batch_number: L1BatchNumber,
+) -> Result<bool> {
+    if !is_quote_matching_policy(attestation_policy, quote_verification_result) {
+        return Ok(false);
+    }
+
+    let batch_no = batch_number.0;
+
+    let public_key = PublicKey::from_slice(
+        &quote_verification_result.quote.report_body.reportdata[..PUBLIC_KEY_SIZE],
+    )?;
+    debug!(batch_no, "public key: {}", public_key);
+
+    let root_hash = node_client.get_root_hash(batch_number).await?;
+    debug!(batch_no, "root hash: {}", root_hash);
+
+    let is_verified = verify_signature(signature, public_key, root_hash)?;
+    if is_verified {
+        info!(batch_no, signature = %encode(signature), "Signature verified successfully.");
+    } else {
+        warn!(batch_no, signature = %encode(signature), "Failed to verify signature!");
+    }
+    Ok(is_verified)
+}
+
+pub fn verify_attestation_quote(attestation_quote_bytes: &[u8]) -> Result<QuoteVerificationResult> {
+    let collateral =
+        tee_qv_get_collateral(attestation_quote_bytes).context("Failed to get collateral!")?;
+    let unix_time: i64 = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_secs() as _;
+    verify_quote_with_collateral(attestation_quote_bytes, Some(&collateral), unix_time)
+        .context("Failed to verify quote with collateral!")
+}
+
+pub fn log_quote_verification_summary(quote_verification_result: &QuoteVerificationResult) {
+    let QuoteVerificationResult {
+        collateral_expired,
+        result,
+        quote,
+        advisories,
+        ..
+    } = quote_verification_result;
+    if *collateral_expired {
+        warn!("Freshly fetched collateral expired!");
+    }
+    let tcblevel = TcbLevel::from(*result);
+    info!(
+        "Quote verification result: {}. mrsigner: {}, mrenclave: {}, reportdata: {}. Advisory IDs: {}.",
+        tcblevel,
+        hex::encode(quote.report_body.mrsigner),
+        hex::encode(quote.report_body.mrenclave),
+        hex::encode(quote.report_body.reportdata),
+        if advisories.is_empty() {
+            "None".to_string()
+        } else {
+            advisories.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
+        }
+    );
+}
+
+fn verify_signature(signature: &[u8], public_key: PublicKey, root_hash: H256) -> Result<bool> {
+    let signature = Signature::from_compact(signature)?;
+    let root_hash_msg = Message::from_digest_slice(&root_hash.0)?;
+    Ok(signature.verify(&root_hash_msg, &public_key).is_ok())
+}
+
+fn is_quote_matching_policy(
+    attestation_policy: &AttestationPolicyArgs,
+    quote_verification_result: &QuoteVerificationResult<'_>,
+) -> bool {
+    let quote = &quote_verification_result.quote;
+    let tcblevel = TcbLevel::from(quote_verification_result.result);
+
+    if !attestation_policy.sgx_allowed_tcb_levels.contains(tcblevel) {
+        warn!(
+            "Quote verification failed: TCB level mismatch (expected one of: {:?}, actual: {})",
+            attestation_policy.sgx_allowed_tcb_levels, tcblevel
+        );
+        return false;
+    }
+
+    check_policy(
+        attestation_policy.sgx_mrsigners.as_deref(),
+        &quote.report_body.mrsigner,
+        "mrsigner",
+    ) && check_policy(
+        attestation_policy.sgx_mrenclaves.as_deref(),
+        &quote.report_body.mrenclave,
+        "mrenclave",
+    )
+}
+
+fn check_policy(policy: Option<&str>, actual_value: &[u8], field_name: &str) -> bool {
+    if let Some(valid_values) = policy {
+        let valid_values: Vec<&str> = valid_values.split(',').collect();
+        let actual_value = hex::encode(actual_value);
+        if !valid_values.contains(&actual_value.as_str()) {
+            warn!(
+                "Quote verification failed: {} mismatch (expected one of: {:?}, actual: {})",
+                field_name, valid_values, actual_value
+            );
+            return false;
+        }
+        debug!(field_name, actual_value, "Attestation policy check passed");
+    }
+    true
+}


### PR DESCRIPTION
This PR introduces TEE Prover continuous mode with attestation policies.

Attestation policies are a set of criteria that determine whether an SGX attestation should be considered valid or invalid. In practice, this means checking against a specified set of [`mrsigners`][1], [`mrenclaves`][1], and [TCB levels][2]. If the attestation’s `mrenclave`/`mrsigner`/TCB levels matches those in the provided `--sgx-mrenclaves`/`--sgx-mrsigners`/`--sgx-allowed-tcb-levels`, we treat the attestation as successfully verified. Otherwise, the attestation is considered invalid.

The `--continuous` mode for the TEE Prover allows it to run continuously, verifying new batches exposed by the node's RPC API in real-time.

To try it out, run the following commands:
```
$ nix build -L .#container-verify-era-proof-attestation-sgx
$ export IMAGE_TAG=$(docker load -i result | grep -Po 'Loaded image.*: \K.*')
$ docker run  -i --init --rm $IMAGE_TAG --continuous 11505 --rpc https://sepolia.era.zksync.dev --sgx-allowed-tcb-levels Ok,SwHardeningNeeded --log-level debug
$ docker run  -i --init --rm $IMAGE_TAG --batch 11509 --rpc https://sepolia.era.zksync.dev --sgx-allowed-tcb-levels Ok,SwHardeningNeeded --log-level debug
```

[1]: https://www.intel.com/content/www/us/en/developer/articles/technical/introduction-to-intel-sgx-sealing.html
[2]: https://docs.trustauthority.intel.com/main/articles/concept-platform-tcb.html