### PR TITLE
chore(nix): set shell environment for openssl

### DIFF
--- a/shells/teepot/default.nix
+++ b/shells/teepot/default.nix
@@ -10,6 +10,10 @@
 mkShell {
   inputsFrom = [ teepot.teepot ];
 
+  shellHook = ''
+    export OPENSSL_NO_VENDOR="1";
+  '';
+
   packages = [
     dive
     taplo


### PR DESCRIPTION
The shellHook statement has been added to export OPENSSL_NO_VENDOR as 1. This should prevent building the vendored version of openssl.