### PR TITLE
feat(tee): use hex deserialization for RPC requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5636,6 +5636,7 @@ dependencies = [
  "reqwest 0.12.7",
  "secp256k1 0.29.1",
  "serde",
+ "serde_with 3.9.0",
  "teepot",
  "tokio",
  "tracing",

--- a/bin/verify-era-proof-attestation/Cargo.toml
+++ b/bin/verify-era-proof-attestation/Cargo.toml
@@ -16,6 +16,7 @@ jsonrpsee-types.workspace = true
 reqwest.workspace = true
 secp256k1.workspace = true
 serde.workspace = true
+serde_with = { workspace = true, features = ["hex"] }
 teepot.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/bin/verify-era-proof-attestation/src/proof.rs
+++ b/bin/verify-era-proof-attestation/src/proof.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Result};
 use jsonrpsee_types::error::ErrorObject;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use serde_with::{hex::Hex, serde_as};
 use std::time::Duration;
 use tokio::sync::watch;
 use tracing::{error, warn};
@@ -146,14 +147,19 @@ pub struct GetProofsResponse {
     pub error: Option<ErrorObject<'static>>,
 }
 
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Proof {
     pub l1_batch_number: u32,
     pub tee_type: String,
+    #[serde_as(as = "Hex")]
     pub pubkey: Vec<u8>,
+    #[serde_as(as = "Hex")]
     pub signature: Vec<u8>,
+    #[serde_as(as = "Hex")]
     pub proof: Vec<u8>,
     pub proved_at: String,
+    #[serde_as(as = "Hex")]
     pub attestation: Vec<u8>,
 }


### PR DESCRIPTION
Following Anton's suggestion, we have switched to hex serialization for API/RPC requests and responses. Previously, we used default JSON serialization for Vec<u8>, which resulted in a lengthy comma-separated list of integers.

This change standardizes serialization, making it more efficient and reducing the size of the responses. The previous format, with a series of comma-separated integers for pubkey-like fields, looked odd.

Then:
```
curl -X POST\
     -H "Content-Type: application/json" \
     --data '{"jsonrpc": "2.0", "id": 1, "method": "unstable_getTeeProofs", "params": [491882, "Sgx"] }' \
        https://mainnet.era.zksync.io
{"jsonrpc":"2.0","result":[{"attestation":[3,0,2,0,0,0,0,0,10,<dozens of comma-separated integers here>
```

Now:
```
$ curl -X POST \
       -H "Content-Type: application/json" \
       --data '{"jsonrpc": "2.0", "id": 1, "method": "unstable_getTeeProofs", "params": [1, "sgx"] }' \
          http://localhost:3050
{"jsonrpc":"2.0","result":[{"l1BatchNumber":1,"teeType":"sgx","pubkey":"0506070809","signature":"0001020304","proof":"0a0b0c0d0e","provedAt":"2024-09-16T11:53:38.253033Z","attestation":"0403020100"}],"id":1}
```

This change needs to be deployed in lockstep with: https://github.com/matter-labs/zksync-era/pull/2887.