### PR TITLE
fix(flake.nix): remove redundant crane input follow

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,6 @@
 
     crane = {
       url = "github:ipetkov/crane?tag=v0.17.3";
-      inputs.nixpkgs.follows = "nixsgx-flake/nixpkgs";
     };
   };
 


### PR DESCRIPTION
- Removed the unnecessary crane input follow from flake.nix.

```
warning: input 'crane' has an override for a non-existent input 'nixpkgs'
```