### PR TITLE
refactor(logging): enhance logging setup and usage

### DIFF
--- a/bin/vault-admin/src/main.rs
+++ b/bin/vault-admin/src/main.rs
@@ -110,7 +110,10 @@ struct Arguments {
 async fn main() -> Result<()> {
     let args = Arguments::parse();
 
-    setup_logging(&args.log_level)?;
+    tracing::subscriber::set_global_default(setup_logging(
+        env!("CARGO_CRATE_NAME"),
+        &args.log_level,
+    )?)?;
 
     info!("Quote verified! Connection secure!");
 

--- a/bin/verify-era-proof-attestation/src/main.rs
+++ b/bin/verify-era-proof-attestation/src/main.rs
@@ -26,7 +26,11 @@ use zksync_basic_types::L1BatchNumber;
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Arguments::parse();
-    setup_logging(&args.log_level)?;
+    tracing::subscriber::set_global_default(setup_logging(
+        env!("CARGO_CRATE_NAME"),
+        &args.log_level,
+    )?)?;
+
     validate_arguments(&args)?;
     let (stop_sender, stop_receiver) = watch::channel(false);
     let mut process_handle = tokio::spawn(verify_batches_proofs(stop_receiver, args));


### PR DESCRIPTION
- Modified the `setup_logging` function to return a `Subscriber`, improving flexibility and reuse.
- Integrated `tracing::subscriber::set_global_default` in the main functions to establish the logging subscriber globally.
- Added configurations for span events and control over file and line information display.