### PR TITLE
fix(proof-validation): handle optional proof status

### DIFF
--- a/bin/verify-era-proof-attestation/src/main.rs
+++ b/bin/verify-era-proof-attestation/src/main.rs
@@ -155,7 +155,10 @@ async fn verify_batch_proofs(
         total_proofs_count += 1;
         let tee_type = proof.tee_type.to_uppercase();
 
-        if proof.status.eq_ignore_ascii_case("permanently_ignored") {
+        if proof
+            .status
+            .map_or(false, |s| s.eq_ignore_ascii_case("permanently_ignored"))
+        {
             trace!(
                 batch_no,
                 tee_type,

--- a/bin/verify-era-proof-attestation/src/proof.rs
+++ b/bin/verify-era-proof-attestation/src/proof.rs
@@ -39,8 +39,9 @@ pub async fn get_proofs(
 
         if !proofs.is_empty()
             && proofs.iter().all(|proof| {
-                !proof.status.eq_ignore_ascii_case("failed")
-                    && !proof.status.eq_ignore_ascii_case("picked_by_prover")
+                !proof.status.as_ref().map_or(false, |s| {
+                    s.eq_ignore_ascii_case("failed") | s.eq_ignore_ascii_case("picked_by_prover")
+                })
             })
         {
             return Ok(proofs);
@@ -165,7 +166,7 @@ pub struct Proof {
     #[serde_as(as = "Option<Hex>")]
     pub proof: Option<Vec<u8>>,
     pub proved_at: String,
-    pub status: String,
+    pub status: Option<String>,
     #[serde_as(as = "Option<Hex>")]
     pub attestation: Option<Vec<u8>>,
 }


### PR DESCRIPTION
Ensure proof status is treated as optional, preventing crashes when status is absent.
- Modify status field to `Option<String>` in `Proof` struct.
- Update validation logic to handle `None` values safely.
- Adjust main logic to check for "permanently_ignored" safely.