### PR TITLE
feat(tee-key-preexec): support for Solidity-compatible pubkey in report_data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5214,8 +5214,10 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
+ "hex",
  "rand",
  "secp256k1 0.29.1",
+ "sha3",
  "teepot",
  "tracing",
  "tracing-log 0.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 serde_with = { version = "3.8", features = ["base64", "hex"] }
 sha2 = "0.10.8"
+sha3 = "0.10.8"
 signature = "2.2.0"
 tdx-attest-rs = { version = "0.1.2", git = "https://github.com/intel/SGXDataCenterAttestationPrimitives.git", rev = "aa239d25a437a28f3f4de92c38f5b6809faac842" }
 teepot = { path = "crates/teepot" }

--- a/bin/tee-key-preexec/Cargo.toml
+++ b/bin/tee-key-preexec/Cargo.toml
@@ -12,8 +12,10 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+hex.workspace = true
 rand.workspace = true
 secp256k1.workspace = true
+sha3.workspace = true
 teepot.workspace = true
 tracing.workspace = true
 tracing-log.workspace = true


### PR DESCRIPTION
This PR is part of the effort to implement on-chain TEE proof verification. This PR goes hand in hand with https://github.com/matter-labs/zksync-era/pull/3414.