### PR TITLE
feat(google-tdx): add vector pushing to kafka for logging

### DIFF
--- a/packages/tdx_google/configuration.nix
+++ b/packages/tdx_google/configuration.nix
@@ -26,6 +26,13 @@
   networking.firewall.allowedTCPPortRanges = [{ from = 1024; to = 65535; }];
   networking.firewall.allowedUDPPortRanges = [{ from = 1024; to = 65535; }];
 
+  services.resolved.enable = true;
+  services.resolved.llmnr = "false";
+  services.resolved.extraConfig = ''
+    [Resolve]
+    MulticastDNS=no
+  '';
+
   networking.useNetworkd = lib.mkDefault true;
 
   # don't fill up the logs
@@ -80,8 +87,6 @@
     disabledCollectors = [
       "textfile"
     ];
-    #openFirewall = true;
-    #firewallFilter = "-i br0 -p tcp -m tcp --dport 9100";
   };
 
   environment.systemPackages = with pkgs; [

--- a/packages/tdx_google/configuration.nix
+++ b/packages/tdx_google/configuration.nix
@@ -8,19 +8,6 @@
     "${toString modulesPath}/profiles/qemu-guest.nix"
   ];
 
-  /*
-    # SSH login for debugging
-    services.sshd.enable = true;
-    networking.firewall.allowedTCPPorts = [ 22 ];
-    services.openssh.settings.PermitRootLogin = lib.mkOverride 999 "yes";
-    users.users.root.openssh.authorizedKeys.keys = [
-    "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIDsb/Tr69YN5MQLweWPuJaRGm+h2kOyxfD6sqKEDTIwoAAAABHNzaDo="
-    "sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBACLgT81iB1iWWVuXq6PdQ5GAAGhaZhSKnveQCvcNnAOZ5WKH80bZShKHyAYzrzbp8IGwLWJcZQ7TqRK+qZdfagAAAAEc3NoOg=="
-    "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBAYbUTKpy4QR3s944/hjJ1UK05asFEs/SmWeUbtS0cdA660sT4xHnRfals73FicOoz+uIucJCwn/SCM804j+wtM="
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMNsmP15vH8BVKo7bdvIiiEjiQboPGcRPqJK0+bH4jKD"
-    ];
-  */
-
   # the container might want to listen on ports
   networking.firewall.enable = true;
   networking.firewall.allowedTCPPortRanges = [{ from = 1024; to = 65535; }];

--- a/systems/x86_64-linux/tdxtest/default.nix
+++ b/systems/x86_64-linux/tdxtest/default.nix
@@ -34,6 +34,11 @@
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMNsmP15vH8BVKo7bdvIiiEjiQboPGcRPqJK0+bH4jKD"
   ];
 
+  environment.systemPackages = with pkgs; [
+    strace
+    tcpdump
+  ];
+
 
   fileSystems = {
     "/" = {


### PR DESCRIPTION
- Enable Vector service and configure OpenTelemetry source.
- Add sinks for logs output to console and Kafka.
- Configure environment setup for Kafka using GCP metadata API.
-  removed commented-out ssh debugging
- Configured resolved service, disabling LLMNR and MulticastDNS
   for improved resolution settings.    
- Removed commented-out Prometheus Node config
