### PR TITLE
feat(configuration): update journald and serial settings

### DIFF
--- a/packages/tdx_google/configuration.nix
+++ b/packages/tdx_google/configuration.nix
@@ -63,6 +63,9 @@
     ''
   );
 
+  services.journald.console = "/dev/ttyS0";
+  systemd.services."serial-getty@ttyS0".enable = lib.mkForce false;
+
   # the container might want to listen on ports
   networking.firewall.enable = true;
   networking.firewall.allowedTCPPortRanges = [{ from = 1024; to = 65535; }];


### PR DESCRIPTION
- Set journald console to `/dev/ttyS0` for improved logging.
- Disable `serial-getty@ttyS0` service to avoid conflicts.