### PR TITLE
feat(tdx_google): add support for attestation in container

### DIFF
--- a/packages/tdx_google/container.nix
+++ b/packages/tdx_google/container.nix
@@ -23,12 +23,14 @@
       echo "Measuring $DIGEST" >&2
       test -c /dev/tdx_guest && tdx-extend --digest "$DIGEST" --rtmr 3
 
+      # /sys/kernel/config is needed for attestation
       docker run -d --rm \
         --name tdx_container \
         --env "GOOGLE_METADATA=1" \
         --network=host \
         --init \
         --privileged \
+        -v /sys/kernel/config:/sys/kernel/config \
         "sha256:$DIGEST"
       exec docker wait tdx_container
     '';


### PR DESCRIPTION
- Mount `/sys/kernel/config` to enable attestation for TDX containers.
- Ensures compatibility with TDX guest measurements during runtime.