### PR TITLE
feat(tdx_google): add onFailure action to reboot on metadata.service errors

### DIFF
--- a/packages/tdx_google/metadata.nix
+++ b/packages/tdx_google/metadata.nix
@@ -49,5 +49,8 @@
       KAFKA_URLS="''${KAFKA_URLS}"
       EOF
     '';
+    postStop = lib.mkDefault ''
+      shutdown --reboot +5
+    '';
   };
 }


### PR DESCRIPTION
- Introduce `ExecPostStop` handler to trigger reboot after 5 minutes.
