### PR TITLE
fix(teepot-vault): use `ring` as `CryptoProvider` for `rustls`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ pgp = "0.15"
 pkcs8 = { version = "0.10" }
 reqwest = { version = "0.12", features = ["json"] }
 rsa = { version = "0.9.6", features = ["sha2", "pem"] }
-rustls = { version = "0.23.20" }
+rustls = { version = "0.23.20", default-features = false, features = ["std", "logging", "tls12", "ring"] }
 secp256k1 = { version = "0.30", features = ["rand", "global-context"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/bin/tee-vault-unseal/src/main.rs
+++ b/bin/tee-vault-unseal/src/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2023-2024 Matter Labs
+// Copyright (c) 2023-2025 Matter Labs
 
 //! Server to initialize and unseal the Vault TEE.
 
@@ -9,27 +9,33 @@
 mod init;
 mod unseal;
 
-use actix_web::rt::time::sleep;
-use actix_web::web::Data;
-use actix_web::{web, App, HttpServer};
+use actix_web::{rt::time::sleep, web, web::Data, App, HttpServer};
 use anyhow::{bail, Context, Result};
 use awc::Client;
 use clap::Parser;
 use init::post_init;
 use rustls::ServerConfig;
-use std::fmt::Debug;
-use std::io::Read;
-use std::net::Ipv6Addr;
-use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
-use teepot::client::{AttestationArgs, TeeConnection};
-use teepot::json::http::{Init, Unseal};
-use teepot::json::secrets::AdminConfig;
-use teepot::server::attestation::{get_quote_and_collateral, VaultAttestationArgs};
-use teepot::server::new_json_cfg;
-use teepot::server::pki::make_self_signed_cert;
-use teepot::sgx::{parse_tcb_levels, EnumSet, TcbLevel};
+use std::{
+    fmt::Debug,
+    io::Read,
+    net::Ipv6Addr,
+    path::PathBuf,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+use teepot::{
+    client::{AttestationArgs, TeeConnection},
+    json::{
+        http::{Init, Unseal},
+        secrets::AdminConfig,
+    },
+    server::{
+        attestation::{get_quote_and_collateral, VaultAttestationArgs},
+        new_json_cfg,
+        pki::make_self_signed_cert,
+    },
+    sgx::{parse_tcb_levels, EnumSet, TcbLevel},
+};
 use tracing::{error, info};
 use tracing_log::LogTracer;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
@@ -135,6 +141,8 @@ async fn main() -> Result<()> {
     }
 
     let (report_data, cert_chain, priv_key) = make_self_signed_cert("CN=localhost", None)?;
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
 
     // init server config builder with safe defaults
     let config = ServerConfig::builder()

--- a/bin/vault-admin/README.md
+++ b/bin/vault-admin/README.md
@@ -9,7 +9,7 @@
 Verified signature for `81A312C59D679D930FA9E8B06D728F29A2DBABF8`
 
 ❯ RUST_LOG=info cargo run -p vault-admin -- \
-  send \
+  command \
    --sgx-mrsigner c5591a72b8b86e0d8814d6e8750e3efe66aea2d102b8ba2405365559b858697d \
    --sgx-allowed-tcb-levels SwHardeningNeeded \
    --server https://127.0.0.1:8444 \

--- a/bin/vault-admin/src/main.rs
+++ b/bin/vault-admin/src/main.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2023-2024 Matter Labs
+// Copyright (c) 2023-2025 Matter Labs
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Parser, Subcommand};
@@ -116,8 +116,6 @@ async fn main() -> Result<()> {
         env!("CARGO_CRATE_NAME"),
         &args.log_level,
     )?)?;
-
-    info!("Quote verified! Connection secure!");
 
     match args.cmd {
         SubCommands::Command(args) => send_commands(args).await?,


### PR DESCRIPTION
New `rustls` needs global install of default `CryptoProvider`.