### PR TITLE
fix(verify-era-proof-attestation): handle missing RecoveryId signatures

### DIFF
--- a/bin/verify-era-proof-attestation/src/verification.rs
+++ b/bin/verify-era-proof-attestation/src/verification.rs
@@ -55,7 +55,12 @@ impl TeeProof {
                 if self.signature.len() == 64 {
                     info!("Signature is missing RecoveryId!");
                     // Fallback for missing RecoveryId
-                    for rec_id in [RecoveryId::Zero, RecoveryId::One] {
+                    for rec_id in [
+                        RecoveryId::Zero,
+                        RecoveryId::One,
+                        RecoveryId::Two,
+                        RecoveryId::Three,
+                    ] {
                         let Ok(sig) = RecoverableSignature::from_compact(&sig_vec, rec_id) else {
                             continue;
                         };


### PR DESCRIPTION
- add `RecoveryId::Two` and `RecoveryId::Three`