### PR TITLE
feat(ci): switch to GitHub Container Registry for images

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,10 +2,10 @@ name: nix
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   push:
-    branches: [ "main" ]
-    tags: [ "*" ]
+    branches: ["main"]
+    tags: ["*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,7 +34,7 @@ jobs:
 
   build:
     needs: check
-    runs-on: [ matterlabs-default-infra-runners ]
+    runs-on: [matterlabs-default-infra-runners]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: cachix/install-nix-action@v30
@@ -56,7 +56,7 @@ jobs:
 
   push_to_docker:
     needs: build
-    runs-on: [ matterlabs-default-infra-runners ]
+    runs-on: [matterlabs-default-infra-runners]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.config.nixpackage }}
       cancel-in-progress: true
@@ -90,11 +90,12 @@ jobs:
           cache: tee-pot
           token: ${{ secrets.ATTIC_TOKEN }}
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load container
         id: build
@@ -106,21 +107,21 @@ jobs:
 
       - name: Push container
         run: |
-          echo "Pushing image ${{ steps.build.outputs.IMAGE_TAG }} to Docker Hub"
-          docker tag "${{ steps.build.outputs.IMAGE_TAG }}" matterlabsrobot/"${{ steps.build.outputs.IMAGE_TAG }}"
-          docker push matterlabsrobot/"${{ steps.build.outputs.IMAGE_TAG }}"
+          echo "Pushing image ${{ steps.build.outputs.IMAGE_TAG }} to GitHub Container Registry"
+          docker tag "${{ steps.build.outputs.IMAGE_TAG }}" "ghcr.io/${{ github.repository_owner }}"/"${{ steps.build.outputs.IMAGE_TAG }}"
+          docker push "ghcr.io/${{ github.repository_owner }}"/"${{ steps.build.outputs.IMAGE_TAG }}"
 
       - name: Tag container as latest
         if: ${{ github.event_name == 'push' }}
         run: |
-          docker tag "${{ steps.build.outputs.IMAGE_TAG }}" matterlabsrobot/"${{ steps.build.outputs.IMAGE_NAME }}:latest"
-          docker push matterlabsrobot/"${{ steps.build.outputs.IMAGE_NAME }}:latest"
+          docker tag "${{ steps.build.outputs.IMAGE_TAG }}" "ghcr.io/${{ github.repository_owner }}"/"${{ steps.build.outputs.IMAGE_NAME }}:latest"
+          docker push "ghcr.io/${{ github.repository_owner }}"/"${{ steps.build.outputs.IMAGE_NAME }}:latest"
 
       - name: Tag container with tag
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         run: |
-          docker tag "${{ steps.build.outputs.IMAGE_TAG }}" matterlabsrobot/"${{ steps.build.outputs.IMAGE_NAME }}:$GITHUB_REF_NAME"
-          docker push matterlabsrobot/"${{ steps.build.outputs.IMAGE_NAME }}:$GITHUB_REF_NAME"
+          docker tag "${{ steps.build.outputs.IMAGE_TAG }}" "ghcr.io/${{ github.repository_owner }}"/"${{ steps.build.outputs.IMAGE_NAME }}:$GITHUB_REF_NAME"
+          docker push "ghcr.io/${{ github.repository_owner }}"/"${{ steps.build.outputs.IMAGE_NAME }}:$GITHUB_REF_NAME"
 
       - name: Generate build ID for Flux Image Automation
         id: flux

--- a/assets/gcloud-deploy.sh
+++ b/assets/gcloud-deploy.sh
@@ -45,6 +45,6 @@ gcloud compute instances create tdx-pilot \
          --maintenance-policy=TERMINATE \
          --image-project=tdx-pilot \
          --project tdx-pilot \
-         --metadata=container_hub="docker.io",container_image="matterlabsrobot/test-tdx:117p5y281limw0w7b03v802ij00c5gzw" \
+         --metadata=container_hub="docker.io",container_image="ghcr.io/matter-labs/test-tdx:117p5y281limw0w7b03v802ij00c5gzw" \
          --metadata-from-file=container_config=$BASE_DIR/config.json \
          --image tdx-img-f-"${NO}"

--- a/bin/tee-self-attestation-test/README.md
+++ b/bin/tee-self-attestation-test/README.md
@@ -1,6 +1,6 @@
 # self-attestation-test
 
-Optionally build and load the containers (remove the `matterlabsrobot/` repo from the commands below then)
+Optionally build and load the containers (remove the `ghcr.io/matter-labs/` repo from the commands below then)
 
 ```bash
 $ nix build -L .#container-verify-attestation-sgx && docker load -i result
@@ -12,9 +12,9 @@ $ nix build -L .#container-self-attestation-test-sgx-azure && docker load -i res
 
 ```bash
 ❯ docker run -i --init --rm --privileged --device /dev/sgx_enclave \
-    matterlabsrobot/teepot-self-attestation-test-sgx-azure:latest \
+    ghcr.io/matter-labs/teepot-self-attestation-test-sgx-azure:latest \
     | base64 -d --ignore-garbage \
-    | docker run -i --rm matterlabsrobot/verify-attestation-sgx:latest -
+    | docker run -i --rm ghcr.io/matter-labs/verify-attestation-sgx:latest -
 
 aesm_service: warning: Turn to daemon. Use "--no-daemon" option to execute in foreground.
 Gramine is starting. Parsing TOML manifest file, this may take some time...
@@ -31,9 +31,9 @@ reportdata: 00000000000000000000000000000000000000000000000000000000000000000000
 
 ```bash
 ❯ docker run -i --init --rm --privileged --device /dev/sgx_enclave \
-    matterlabsrobot/teepot-self-attestation-test-sgx-dcap:latest \
+    ghcr.io/matter-labs/teepot-self-attestation-test-sgx-dcap:latest \
     | base64 -d --ignore-garbage \
-    | docker run -i --rm matterlabsrobot/verify-attestation-sgx:latest -
+    | docker run -i --rm ghcr.io/matter-labs/verify-attestation-sgx:latest -
 
 aesm_service: warning: Turn to daemon. Use "--no-daemon" option to execute in foreground.
 Gramine is starting. Parsing TOML manifest file, this may take some time...
@@ -48,9 +48,9 @@ On an outdated machine, this might look like this:
 
 ```bash
 ❯ docker run -i --init --rm --privileged --device /dev/sgx_enclave \
-                matterlabsrobot/teepot-self-attestation-test-sgx-dcap:latest \
+                ghcr.io/matter-labs/teepot-self-attestation-test-sgx-dcap:latest \
                 | base64 -d --ignore-garbage \
-                | docker run -i --rm matterlabsrobot/verify-attestation-sgx:latest -
+                | docker run -i --rm ghcr.io/matter-labs/verify-attestation-sgx:latest -
 
 aesm_service: warning: Turn to daemon. Use "--no-daemon" option to execute in foreground.
 Gramine is starting. Parsing TOML manifest file, this may take some time...
@@ -73,9 +73,9 @@ reportdata: 00000000000000000000000000000000000000000000000000000000000000000000
 
 ```bash
 ❯ podman run -i --rm --group-add=keep-groups -v /var/run/aesmd:/var/run/aesmd -v /dev/sgx_enclave:/dev/sgx_enclave \
-  matterlabsrobot/teepot-self-attestation-test-sgx-dcap:latest \
+  ghcr.io/matter-labs/teepot-self-attestation-test-sgx-dcap:latest \
   | base64 -d --ignore-garbage \
   | podman run -i --rm --net host \
   -v /etc/sgx_default_qcnl.conf:/etc/sgx_default_qcnl.conf \
-  matterlabsrobot/verify-attestation-sgx-dcap:latest
+  ghcr.io/matter-labs/verify-attestation-sgx-dcap:latest
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -121,7 +121,7 @@ Passphrase:
 Find out the `mr_enclave` value of the teepot-vault-admin-sgx-azure enclave and extract the sigstruct file:
 
 ```bash
-❯ docker run -v .:/mnt --pull always -it matterlabsrobot/teepot-vault-admin-sgx-azure:latest 'gramine-sgx-sigstruct-view teepot-vault-admin-sgx-azure.sig; cp teepot-vault-admin-sgx-azure.sig /mnt'
+❯ docker run -v .:/mnt --pull always -it ghcr.io/matter-labs/teepot-vault-admin-sgx-azure:latest 'gramine-sgx-sigstruct-view teepot-vault-admin-sgx-azure.sig; cp teepot-vault-admin-sgx-azure.sig /mnt'
 [...]
 Attributes:
     mr_signer: c5591a72b8b86e0d8814d6e8750e3efe66aea2d102b8ba2405365559b858697d
@@ -226,18 +226,18 @@ Next is to sign the admin tee with the vault-admin tool:
 ```
 
 Then replace `teepot-vault-admin-sgx-azure.sig` with `teepot-vault-admin-sgx-azure-new.sig` in the container
-image `matterlabsrobot/teepot-vault-admin-sgx-azure:latest` with this Dockerfile:
+image `ghcr.io/matter-labs/teepot-vault-admin-sgx-azure:latest` with this Dockerfile:
 
 ```Dockerfile
-FROM matterlabsrobot/teepot-vault-admin-sgx-azure:latest
+FROM ghcr.io/matter-labs/teepot-vault-admin-sgx-azure:latest
 COPY teepot-vault-admin-sgx-azure-new.sig /app/teepot-vault-admin-sgx-azure.sig
 ```
 
 Build and push the new image:
 
 ```bash
-❯ docker build -t matterlabsrobot/teepot-vault-admin-sgx-azure-signed:latest .
-❯ docker push matterlabsrobot/teepot-vault-admin-sgx-azure-signed:latest
+❯ docker build -t ghcr.io/matter-labs/teepot-vault-admin-sgx-azure-signed:latest .
+❯ docker push ghcr.io/matter-labs/teepot-vault-admin-sgx-azure-signed:latest
 ```
 
 Delete the old vault-admin pod and start the new one:

--- a/examples/k8s/vault-1-pod.yaml
+++ b/examples/k8s/vault-1-pod.yaml
@@ -27,7 +27,7 @@ spec:
   imagePullSecrets:
     - name: docker-regcred
   containers:
-    - image: matterlabsrobot/teepot-vault-sgx-azure:latest
+    - image: ghcr.io/matter-labs/teepot-vault-sgx-azure:latest
       name: vault
       imagePullPolicy: Always
       env:
@@ -62,7 +62,7 @@ spec:
       volumeMounts:
         - mountPath: /opt/vault/data
           name: data-1
-    - image: matterlabsrobot/teepot-vault-unseal-sgx-azure:latest
+    - image: ghcr.io/matter-labs/teepot-vault-unseal-sgx-azure:latest
       name: vault-unseal
       imagePullPolicy: Always
       env:

--- a/examples/k8s/vault-2-pod.yaml
+++ b/examples/k8s/vault-2-pod.yaml
@@ -27,7 +27,7 @@ spec:
   imagePullSecrets:
     - name: docker-regcred
   containers:
-    - image: matterlabsrobot/teepot-vault-sgx-azure:latest
+    - image: ghcr.io/matter-labs/teepot-vault-sgx-azure:latest
       name: vault
       imagePullPolicy: Always
       env:
@@ -62,7 +62,7 @@ spec:
       volumeMounts:
         - mountPath: /opt/vault/data
           name: data-2
-    - image: matterlabsrobot/teepot-vault-unseal-sgx-azure:latest
+    - image: ghcr.io/matter-labs/teepot-vault-unseal-sgx-azure:latest
       name: vault-unseal
       imagePullPolicy: Always
       env:

--- a/examples/k8s/vault-3-pod.yaml
+++ b/examples/k8s/vault-3-pod.yaml
@@ -27,7 +27,7 @@ spec:
   imagePullSecrets:
     - name: docker-regcred
   containers:
-    - image: matterlabsrobot/teepot-vault-sgx-azure:latest
+    - image: ghcr.io/matter-labs/teepot-vault-sgx-azure:latest
       name: vault
       imagePullPolicy: Always
       env:
@@ -62,7 +62,7 @@ spec:
       volumeMounts:
         - mountPath: /opt/vault/data
           name: data-3
-    - image: matterlabsrobot/teepot-vault-unseal-sgx-azure:latest
+    - image: ghcr.io/matter-labs/teepot-vault-unseal-sgx-azure:latest
       name: vault-unseal
       imagePullPolicy: Always
       env:

--- a/examples/k8s/vault-unseal-pod-0.yaml
+++ b/examples/k8s/vault-unseal-pod-0.yaml
@@ -11,7 +11,7 @@ spec:
       operator: Exists
       effect: NoSchedule
   containers:
-    - image: matterlabsrobot/teepot-vault-unseal-sgx-azure:latest
+    - image: ghcr.io/matter-labs/teepot-vault-unseal-sgx-azure:latest
       name: vault-unseal
       imagePullPolicy: Always
       env:

--- a/examples/k8s/vault-unseal-pod-1.yaml
+++ b/examples/k8s/vault-unseal-pod-1.yaml
@@ -11,7 +11,7 @@ spec:
       operator: Exists
       effect: NoSchedule
   containers:
-    - image: matterlabsrobot/teepot-vault-unseal-sgx-azure:latest
+    - image: ghcr.io/matter-labs/teepot-vault-unseal-sgx-azure:latest
       name: vault-unseal
       imagePullPolicy: Always
       env:

--- a/examples/k8s/vault-unseal-pod-2.yaml
+++ b/examples/k8s/vault-unseal-pod-2.yaml
@@ -11,7 +11,7 @@ spec:
       operator: Exists
       effect: NoSchedule
   containers:
-    - image: matterlabsrobot/teepot-vault-unseal-sgx-azure:latest
+    - image: ghcr.io/matter-labs/teepot-vault-unseal-sgx-azure:latest
       name: vault-unseal
       imagePullPolicy: Always
       env:

--- a/systems/x86_64-linux/tdxtest/default.nix
+++ b/systems/x86_64-linux/tdxtest/default.nix
@@ -29,7 +29,7 @@
 
   systemd.services.docker_start_container = {
     #    environment = {
-    #      CONTAINER_IMAGE = "matterlabsrobot/tdx-test:pnj1ryxxb8gbzk9wh18s9bcqrzr1z9ff";
+    #      CONTAINER_IMAGE = "ghcr.io/matter-labs/tdx-test:pnj1ryxxb8gbzk9wh18s9bcqrzr1z9ff";
     #      CONTAINER_HUB = "docker.io";
     #      CONTAINER_TOKEN = "";
     #      CONTAINER_USER = "";

--- a/systems/x86_64-linux/tdxtest/web-root/computeMetadata/v1/instance/attributes/container_image
+++ b/systems/x86_64-linux/tdxtest/web-root/computeMetadata/v1/instance/attributes/container_image
@@ -1,1 +1,1 @@
-matterlabsrobot/tdx-test:81hgl91s5hj0sb83c7ij9acf2s5qjvb5
+ghcr.io/matter-labs/tdx-test:81hgl91s5hj0sb83c7ij9acf2s5qjvb5


### PR DESCRIPTION
Updated the workflow to push container images to GitHub Container Registry instead of Docker Hub. Added a login step for GHCR and updated image tagging and pushing commands accordingly.