### PR TITLE
chore(deps): update `teepot` crates to version 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,9 @@ serde_yaml = "0.9.33"
 sha2 = "0.10.8"
 sha3 = "0.10.8"
 signature = "2.2.0"
-teepot = { path = "crates/teepot" }
+teepot = { version = "0.6.0", path = "crates/teepot" }
 teepot-tee-quote-verification-rs = { version = "0.6.0", path = "crates/teepot-tee-quote-verification-rs" }
-teepot-vault = { path = "crates/teepot-vault" }
+teepot-vault = { version = "0.6.0", path = "crates/teepot-vault" }
 testaso = "0.1.0"
 thiserror = "2.0.11"
 tokio = { version = "1", features = ["sync", "macros", "rt-multi-thread", "fs", "time", "signal"] }


### PR DESCRIPTION
- Set `teepot`, `teepot-tee-quote-verification-rs`, and `teepot-vault` crate versions to 0.6.0 in `Cargo.toml`.
- Ensures consistency with the planned 0.6.0 release preparation.