### PR TITLE
docs: add README files for teepot-related crates

### DIFF
--- a/crates/teepot-tdx-attest-rs/README.md
+++ b/crates/teepot-tdx-attest-rs/README.md
@@ -1,0 +1,149 @@
+# teepot-tdx-attest-rs
+
+[![Crates.io](https://img.shields.io/crates/v/teepot-tdx-attest-rs.svg)](https://crates.io/crates/teepot-tdx-attest-rs)
+[![Documentation](https://docs.rs/teepot-tdx-attest-rs/badge.svg)](https://docs.rs/teepot-tdx-attest-rs)
+[![License](https://img.shields.io/crates/l/teepot-tdx-attest-rs.svg)](LICENSE)
+
+Rust bindings for Intel TDX (Trust Domain Extensions) attestation functionality. This crate provides a safe Rust interface to the Intel TDX attestation library, enabling trusted execution environments to generate attestation quotes and reports.
+
+This is a fork of the original [tdx-attest-rs](https://github.com/intel/SGXDataCenterAttestationPrimitives) crate, maintained as part of the [Teepot](https://github.com/matter-labs/teepot) project.
+
+## Features
+
+- Request TDX attestation quotes
+- Generate TDX reports
+- Extend runtime measurement registers (RTMRs)
+- Query supported attestation key IDs
+- Safe Rust wrappers around the Intel TDX attestation C library
+
+## Installation
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+teepot-tdx-attest-rs = "0.1.2"
+```
+
+## Usage
+
+### Generate a TDX Quote
+
+```rust
+use teepot_tdx_attest_rs::*;
+
+// Prepare report data (typically a hash you want to bind to the quote)
+let tdx_report_data = tdx_report_data_t {
+    d: [0; 64], // Your data here
+};
+
+// List of supported attestation key IDs
+let att_key_id_list = [tdx_uuid_t {
+    d: [0; 16], // Your key ID
+}];
+
+let mut att_key_id = tdx_uuid_t {
+    d: [0; 16],
+};
+
+// Request the quote
+let (result, quote) = tdx_att_get_quote(
+    Some(&tdx_report_data),
+    Some(&att_key_id_list),
+    Some(&mut att_key_id),
+    0
+);
+
+match result {
+    tdx_attest_error_t::TDX_ATTEST_SUCCESS => {
+        // Process the quote
+        if let Some(quote_data) = quote {
+            println!("Quote generated successfully, size: {}", quote_data.len());
+        }
+    }
+    _ => {
+        println!("Failed to generate quote: {:?}", result);
+    }
+}
+```
+
+### Generate a TDX Report
+
+```rust
+use teepot_tdx_attest_rs::*;
+
+let tdx_report_data = tdx_report_data_t {
+    d: [0; 64], // Your report data
+};
+
+let mut tdx_report = tdx_report_t {
+    d: [0; 1024],
+};
+
+let result = tdx_att_get_report(Some(&tdx_report_data), &mut tdx_report);
+
+if result == tdx_attest_error_t::TDX_ATTEST_SUCCESS {
+    println!("Report generated successfully");
+}
+```
+
+### Extend RTMR
+
+```rust
+use teepot_tdx_attest_rs::*;
+
+// Prepare RTMR event data
+let rtmr_event = vec![0u8; 68]; // Your event data
+
+let result = tdx_att_extend(&rtmr_event);
+
+if result == tdx_attest_error_t::TDX_ATTEST_SUCCESS {
+    println!("RTMR extended successfully");
+}
+```
+
+### Get Supported Attestation Key IDs
+
+```rust
+use teepot_tdx_attest_rs::*;
+
+let (result, att_key_ids) = tdx_att_get_supported_att_key_ids();
+
+if result == tdx_attest_error_t::TDX_ATTEST_SUCCESS {
+    if let Some(ids) = att_key_ids {
+        println!("Found {} supported attestation key IDs", ids.len());
+    }
+}
+```
+
+## Error Handling
+
+The crate uses the `tdx_attest_error_t` enum for error reporting. Common error values include:
+
+- `TDX_ATTEST_SUCCESS` - Operation completed successfully
+- `TDX_ATTEST_ERROR_INVALID_PARAMETER` - Invalid parameter provided
+- `TDX_ATTEST_ERROR_DEVICE_FAILURE` - Failed to access TDX attestation device
+- `TDX_ATTEST_ERROR_OUT_OF_MEMORY` - Memory allocation failure
+- `TDX_ATTEST_ERROR_UNSUPPORTED_ATT_KEY_ID` - Unsupported attestation key ID
+
+## Requirements
+
+- Intel TDX-enabled hardware
+- TDX attestation runtime environment
+- The `teepot-tdx-attest-sys` crate (automatically included as a dependency)
+
+## Safety
+
+This crate provides safe Rust wrappers around unsafe FFI calls to the Intel TDX attestation library. All pointer operations are handled internally, and the API uses Rust's type system to ensure safety.
+
+## License
+
+This project is licensed under the BSD-3-Clause License - see the [License.txt](License.txt) file for details.
+
+## Contributing
+
+This is a fork maintained as part of the Teepot project. For contributions, please visit the [Teepot repository](https://github.com/matter-labs/teepot).
+
+## Original Work
+
+This crate is based on Intel's SGX Data Center Attestation Primitives. The original source can be found at [Intel's repository](https://github.com/intel/SGXDataCenterAttestationPrimitives).

--- a/crates/teepot-tdx-attest-sys/README.md
+++ b/crates/teepot-tdx-attest-sys/README.md
@@ -1,0 +1,46 @@
+# teepot-tdx-attest-sys
+
+[![Crates.io](https://img.shields.io/crates/v/teepot-tdx-attest-sys.svg)](https://crates.io/crates/teepot-tdx-attest-sys)
+[![Documentation](https://docs.rs/teepot-tdx-attest-sys/badge.svg)](https://docs.rs/teepot-tdx-attest-sys)
+[![License](https://img.shields.io/crates/l/teepot-tdx-attest-sys.svg)](https://github.com/matter-labs/teepot/blob/main/crates/teepot-tdx-attest-sys/License.txt)
+
+Raw FFI bindings to Intel TDX Attestation Library (`libtdx_attest`).
+
+This crate provides low-level FFI bindings for Intel Trust Domain Extensions (TDX) attestation functionality. It is a fork of the original [tdx-attest-sys](https://github.com/intel/SGXDataCenterAttestationPrimitives) crate from Intel's SGX Data Center Attestation Primitives.
+
+## Prerequisites
+
+Before using this crate, you need to install:
+
+- Intel® SGX DCAP Driver
+- Intel® SGX SDK
+- Intel® SGX DCAP Packages
+- Intel® SGX DCAP PCCS (Provisioning Certificate Caching Service)
+
+Please refer to the [SGX DCAP Linux installation guide](https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf) for detailed installation instructions.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+teepot-tdx-attest-sys = "0.1.0"
+```
+
+This crate provides raw FFI bindings. For a more ergonomic Rust API, consider using a higher-level wrapper crate.
+
+## Building
+
+The crate uses `bindgen` to generate Rust bindings from the C headers during build time. Make sure you have:
+
+- The TDX attestation library (`libtdx_attest`) installed on your system
+- If using Intel SGX SDK, set the `SGX_SDK` environment variable to point to your SDK installation
+
+## License
+
+This project is licensed under the BSD-3-Clause License. See the [License.txt](License.txt) file for details.
+
+## Repository
+
+This crate is part of the [Teepot](https://github.com/matter-labs/teepot) project.

--- a/crates/teepot-tee-quote-verification-rs/README.md
+++ b/crates/teepot-tee-quote-verification-rs/README.md
@@ -1,0 +1,182 @@
+# teepot-tee-quote-verification-rs
+
+[![Crates.io](https://img.shields.io/crates/v/teepot-tee-quote-verification-rs.svg)](https://crates.io/crates/teepot-tee-quote-verification-rs)
+[![Documentation](https://docs.rs/teepot-tee-quote-verification-rs/badge.svg)](https://docs.rs/teepot-tee-quote-verification-rs)
+[![License](https://img.shields.io/crates/l/teepot-tee-quote-verification-rs.svg)](https://github.com/matter-labs/teepot/blob/main/LICENSE)
+
+A Rust wrapper for Intel® Software Guard Extensions (SGX) and Trust Domain Extensions (TDX) quote verification.
+
+This crate is a fork of the original [intel-tee-quote-verification-rs](https://github.com/intel/SGXDataCenterAttestationPrimitives) crate, providing safe Rust bindings for the Intel Quote Verification Library (QVL).
+
+## Features
+
+- Safe Rust wrappers for SGX and TDX quote verification APIs
+- Support for both SGX ECDSA and TDX ECDSA quote verification
+- Collateral management for quote verification
+- Supplemental data handling
+- Cross-platform support (Linux x86_64)
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+teepot-tee-quote-verification-rs = "0.6.0"
+```
+
+### Example: Verify an SGX Quote
+
+```rust
+use teepot_tee_quote_verification_rs::*;
+
+fn verify_sgx_quote(quote: &[u8]) -> Result<(), quote3_error_t> {
+    // Get collateral for the quote
+    let collateral = tee_qv_get_collateral(quote)?;
+    
+    // Get supplemental data size
+    let supp_data_size = sgx_qv_get_quote_supplemental_data_size()?;
+    let mut supp_data = sgx_ql_qv_supplemental_t::default();
+    
+    // Verify the quote
+    let current_time = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+        
+    let (expiration_status, verification_result) = sgx_qv_verify_quote(
+        quote,
+        Some(&collateral),
+        current_time,
+        None, // QvE report info (None for host-based verification)
+        supp_data_size,
+        Some(&mut supp_data),
+    )?;
+    
+    match verification_result {
+        sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK => {
+            println!("Quote verification passed!");
+            Ok(())
+        }
+        _ => {
+            println!("Quote verification failed: {:?}", verification_result);
+            Err(quote3_error_t::SGX_QL_ERROR_INVALID_PARAMETER)
+        }
+    }
+}
+```
+
+### Example: Verify a TDX Quote
+
+```rust
+use teepot_tee_quote_verification_rs::*;
+
+fn verify_tdx_quote(quote: &[u8]) -> Result<(), quote3_error_t> {
+    // Get collateral for the quote
+    let collateral = tee_qv_get_collateral(quote)?;
+    
+    // Get supplemental data size
+    let supp_data_size = tdx_qv_get_quote_supplemental_data_size()?;
+    let mut supp_data = sgx_ql_qv_supplemental_t::default();
+    
+    // Verify the quote
+    let current_time = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+        
+    let (expiration_status, verification_result) = tdx_qv_verify_quote(
+        quote,
+        Some(&collateral),
+        current_time,
+        None, // QvE report info
+        supp_data_size,
+        Some(&mut supp_data),
+    )?;
+    
+    match verification_result {
+        sgx_ql_qv_result_t::SGX_QL_QV_RESULT_OK => {
+            println!("TDX quote verification passed!");
+            Ok(())
+        }
+        _ => {
+            println!("TDX quote verification failed: {:?}", verification_result);
+            Err(quote3_error_t::SGX_QL_ERROR_INVALID_PARAMETER)
+        }
+    }
+}
+```
+
+### Unified TEE Quote Verification
+
+For a unified interface that works with both SGX and TDX quotes:
+
+```rust
+use teepot_tee_quote_verification_rs::*;
+
+fn verify_tee_quote(quote: &[u8]) -> Result<(), quote3_error_t> {
+    // Get collateral
+    let collateral = tee_qv_get_collateral(quote)?;
+    
+    // Get supplemental data version and size
+    let (version, data_size) = tee_get_supplemental_data_version_and_size(quote)?;
+    
+    // Prepare supplemental data descriptor
+    let mut supp_data_desc = tee_supp_data_descriptor_t {
+        major_version: version,
+        data_size,
+        p_data: std::ptr::null_mut(),
+    };
+    
+    // Allocate buffer for supplemental data if needed
+    let mut supp_data_buffer = vec![0u8; data_size as usize];
+    if data_size > 0 {
+        supp_data_desc.p_data = supp_data_buffer.as_mut_ptr();
+    }
+    
+    // Verify quote
+    let current_time = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+        
+    let (expiration_status, verification_result) = tee_verify_quote(
+        quote,
+        Some(&collateral),
+        current_time,
+        None,
+        Some(&mut supp_data_desc),
+    )?;
+    
+    println!("Verification result: {:?}", verification_result);
+    println!("Collateral expiration status: {}", expiration_status);
+    
+    Ok(())
+}
+```
+
+## Platform Support
+
+This crate is currently supported on:
+- Linux x86_64
+
+On other platforms, the crate will compile but provide stub implementations.
+
+## Dependencies
+
+On Linux x86_64, this crate depends on:
+- `intel-tee-quote-verification-sys`: System bindings for Intel QVL
+- `teepot-tdx-attest-rs`: TDX attestation support
+
+## License
+
+This project is licensed under the BSD-3-Clause License. See the [LICENSE](https://github.com/matter-labs/teepot/blob/main/LICENSE) file for details.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request to the [Teepot repository](https://github.com/matter-labs/teepot).
+
+## Related Crates
+
+- [intel-tee-quote-verification-rs](https://github.com/intel/SGXDataCenterAttestationPrimitives) - The original Intel crate
+- [teepot-tdx-attest-rs](https://crates.io/crates/teepot-tdx-attest-rs) - TDX attestation support

--- a/crates/teepot-vault/README.md
+++ b/crates/teepot-vault/README.md
@@ -1,0 +1,134 @@
+# teepot-vault
+
+[![Crates.io](https://img.shields.io/crates/v/teepot-vault.svg)](https://crates.io/crates/teepot-vault)
+[![Documentation](https://docs.rs/teepot-vault/badge.svg)](https://docs.rs/teepot-vault)
+[![License](https://img.shields.io/crates/l/teepot-vault.svg)](LICENSE)
+
+A TEE (Trusted Execution Environment) secret manager that provides secure storage and retrieval of secrets for TEE applications, with a focus on Intel SGX enclaves.
+
+## Features
+
+- **Remote Attestation**: Verify Intel SGX enclaves and other TEEs using attestation reports
+- **Secure Communication**: Establish TLS connections with custom certificate verification based on TEE attestation
+- **HashiCorp Vault Integration**: Store and retrieve secrets with TEE-specific access controls
+- **Multi-signature Support**: PGP-based multi-signature verification for administrative commands
+- **Configurable TCB Levels**: Support for different Trusted Computing Base security levels
+
+## Installation
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+teepot-vault = "0.6.0"
+```
+
+## Usage
+
+### Creating a Vault Connection
+
+```rust
+use teepot_vault::client::{AttestationArgs, VaultConnection};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = AttestationArgs {
+        sgx_mrsigner: Some("your_mrsigner_hex".to_string()),
+        sgx_mrenclave: Some("your_mrenclave_hex".to_string()),
+        server: "https://vault.example.com".to_string(),
+        sgx_allowed_tcb_levels: Some(vec!["Ok".to_string(), "ConfigNeeded".to_string()]),
+    };
+
+    let vault_conn = VaultConnection::new(&args, "my-tee-app".to_string()).await?;
+    
+    Ok(())
+}
+```
+
+### Storing and Retrieving Secrets
+
+```rust
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+struct MySecret {
+    api_key: String,
+    private_key: Vec<u8>,
+}
+
+// Store a secret
+let my_secret = MySecret {
+    api_key: "secret-key".to_string(),
+    private_key: vec![1, 2, 3, 4],
+};
+vault_conn.store_secret(my_secret, "secrets/my-app/config").await?;
+
+// Retrieve a secret
+let secret: MySecret = vault_conn.load_secret("secrets/my-app/config").await?.unwrap();
+```
+
+### Custom TEE Connections
+
+For more control over the connection and custom operations:
+
+```rust
+use teepot_vault::client::TeeConnection;
+
+let tee_conn = TeeConnection::new(&args);
+let client = tee_conn.client(); // Get the HTTP client for custom requests
+
+// Perform custom authenticated requests
+let response = client
+    .get("https://vault.example.com/custom/endpoint")
+    .send()
+    .await?;
+```
+
+## Server Components
+
+The crate also provides server-side utilities for building TEE-aware services:
+
+```rust
+use teepot_vault::server::{HttpResponseError, Status};
+use actix_web::{web, App, HttpServer, Result};
+
+async fn handler() -> Result<String, HttpResponseError> {
+    // Your TEE service logic here
+    Ok("Secure response".to_string())
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            .route("/api/secure", web::get().to(handler))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+```
+
+## Requirements
+
+- Rust 1.70 or later
+- For SGX support: Intel SGX SDK and PSW (Platform Software)
+- HashiCorp Vault instance (for vault operations)
+- TEE environment (Intel SGX, Intel TDX, or compatible)
+
+## Security Considerations
+
+This crate is designed for use in high-security environments. When using it:
+
+1. Always verify attestation reports before trusting a TEE
+2. Use appropriate TCB levels for your security requirements
+3. Ensure proper key management for PGP signatures
+4. Follow HashiCorp Vault best practices for secret management
+
+## License
+
+This project is licensed under the Apache License 2.0 - see the LICENSE file for details.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.

--- a/crates/teepot/README.md
+++ b/crates/teepot/README.md
@@ -1,0 +1,72 @@
+# teepot
+
+TEE (Trusted Execution Environment) utilities for Intel SGX and TDX attestation.
+
+## Overview
+
+Teepot provides comprehensive support for generating and verifying attestation quotes from Intel SGX enclaves and TDX trust domains. It handles the complete attestation workflow including quote generation, collateral fetching, and verification with detailed TCB (Trusted Computing Base) status reporting.
+
+## Features
+
+- **Multi-TEE Support**: Works with both Intel SGX and Intel TDX
+- **Attestation Quote Generation**: Generate quotes with custom report data
+- **Quote Verification**: Verify quotes with automatic collateral fetching
+- **TCB Level Management**: Filter quotes by security level
+- **Cross-Platform**: Native support for Linux x86_64, fallback implementation for other platforms
+- **Gramine SGX Support**: Special support for Gramine-based SGX enclaves
+- **Comprehensive Error Handling**: Detailed error context for debugging
+
+## Usage
+
+### Basic Quote Generation and Verification
+
+```rust
+use teepot::quote::{get_quote, get_collateral, verify_quote_with_collateral};
+
+// Generate a quote with custom data
+let report_data = [0u8; 64]; // Your custom data here
+let quote = get_quote(&report_data)?;
+
+// Fetch collateral for verification
+let collateral = get_collateral(&quote)?;
+
+// Verify the quote
+let result = verify_quote_with_collateral(&quote, collateral.as_ref(), None)?;
+println!("TCB Level: {:?}", result.tcb_level);
+```
+
+### High-Level Attestation API
+
+```rust
+use teepot::quote::attestation::get_quote_and_collateral;
+
+// Generate quote and fetch collateral in one call
+let (quote, collateral, result) = get_quote_and_collateral(&report_data)?;
+```
+
+### TCB Level Filtering
+
+```rust
+use teepot::quote::{TcbLevel, verify_quote_with_collateral};
+
+// Only accept quotes with up-to-date TCB
+let accepted_levels = vec![TcbLevel::Ok];
+let result = verify_quote_with_collateral(&quote, collateral.as_ref(), Some(&accepted_levels))?;
+```
+
+## Supported Platforms
+
+- **Full support**: Linux x86_64 with Intel SGX/TDX drivers
+- **Verification only**: All other platforms via `dcap-qvl`
+
+## Dependencies
+
+On Linux x86_64, the crate uses Intel's DCAP libraries for quote generation. Make sure you have:
+- Intel SGX DCAP Quote Generation Library
+- Intel SGX DCAP Quote Verification Library
+
+## License
+
+This project is licensed under the Apache License, Version 2.0 - see the LICENSE file for details.
+
+Note: Some code is derived from the [Enarx project](https://github.com/enarx/).


### PR DESCRIPTION
- Added comprehensive README files for the following new crates:
  - `teepot`
  - `teepot-tdx-attest-rs`
  - `teepot-tdx-attest-sys`
  - `teepot-tee-quote-verification-rs`
  - `teepot-vault`
- Each includes an overview, usage examples, installation instructions, and licensing details.