### PR TITLE
fix: update extra substituter URL in nixConfig

### DIFF
--- a/.github/workflows/nix-non-x86.yml
+++ b/.github/workflows/nix-non-x86.yml
@@ -21,12 +21,12 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
-            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            substituters = https://cache.nixos.org/ https://static.188.92.12.49.clients.your-server.de/tee-pot
             sandbox = true
       - name: Setup Attic cache
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: https://attic.teepot.org/
+          endpoint: https://static.188.92.12.49.clients.your-server.de/
           cache: tee-pot
           token: ${{ secrets.ATTIC_TOKEN }}
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,12 +22,12 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
-            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            substituters = https://cache.nixos.org/ https://static.188.92.12.49.clients.your-server.de/tee-pot
             sandbox = true
       - name: Setup Attic cache
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: https://attic.teepot.org/
+          endpoint: https://static.188.92.12.49.clients.your-server.de/
           cache: tee-pot
           token: ${{ secrets.ATTIC_TOKEN }}
 
@@ -44,12 +44,12 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
-            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            substituters = https://cache.nixos.org/ https://static.188.92.12.49.clients.your-server.de/tee-pot
             sandbox = true
       - name: Setup Attic cache
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: https://attic.teepot.org/
+          endpoint: https://static.188.92.12.49.clients.your-server.de/
           cache: tee-pot
           token: ${{ secrets.ATTIC_TOKEN }}
 
@@ -84,12 +84,12 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ github.token }}
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=
-            substituters = https://cache.nixos.org/ https://attic.teepot.org/tee-pot
+            substituters = https://cache.nixos.org/ https://static.188.92.12.49.clients.your-server.de/tee-pot
             sandbox = true
       - name: Setup Attic cache
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: https://attic.teepot.org/
+          endpoint: https://static.188.92.12.49.clients.your-server.de/
           cache: tee-pot
           token: ${{ secrets.ATTIC_TOKEN }}
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "teepot";
 
   nixConfig = {
-    extra-substituters = [ "https://attic.teepot.org/tee-pot" ];
+    extra-substituters = [ "https://static.188.92.12.49.clients.your-server.de/tee-pot" ];
     extra-trusted-public-keys = [ "tee-pot:SS6HcrpG87S1M6HZGPsfo7d1xJccCGev7/tXc5+I4jg=" ];
   };
 


### PR DESCRIPTION
- Replaced outdated substituter URL with a new static IP-based URL.
- Ensures proper configuration and access to the required substituter.